### PR TITLE
Added google map in event detail page

### DIFF
--- a/get_together/templates/get_together/events/show_event.html
+++ b/get_together/templates/get_together/events/show_event.html
@@ -202,7 +202,7 @@ textarea {
             </div>
             {% endif %}
 
-            {% if event.place %}
+            {% if event.place and settings.GOOGLE_MAPS_API_KEY %}
             <div class="row mb-2">
               <div class="col-12">
                 <iframe

--- a/get_together/templates/get_together/events/show_event.html
+++ b/get_together/templates/get_together/events/show_event.html
@@ -202,6 +202,7 @@ textarea {
             </div>
             {% endif %}
 
+            {% if event.place %}
             <div class="row mb-2">
               <div class="col-12">
                 <iframe
@@ -212,8 +213,8 @@ textarea {
                   allowfullscreen>
                 </iframe>
               </div>
-
             </div>
+            {% endif %}
 
             {% if event.enable_presentations %}
             <div class="row mb-2">

--- a/get_together/templates/get_together/events/show_event.html
+++ b/get_together/templates/get_together/events/show_event.html
@@ -208,13 +208,13 @@ textarea {
                   width="100%"
                   height="300"
                   frameborder="0" style="border:0"
-                  src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{event.place.name|urlencode}}%2C%20{{event.place.address|urlencode}}&zoom=17"
+                  src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{event.place.address|urlencode}}%2C%20{{event.place.city|urlencode}}&zoom=14"
                   allowfullscreen>
                 </iframe>
               </div>
 
             </div>
-            
+
             {% if event.enable_presentations %}
             <div class="row mb-2">
 	            <div class="col-3" width="120px"><b>{% trans "Presentations:" %}</b></div>

--- a/get_together/templates/get_together/events/show_event.html
+++ b/get_together/templates/get_together/events/show_event.html
@@ -202,6 +202,19 @@ textarea {
             </div>
             {% endif %}
 
+            <div class="row mb-2">
+              <div class="col-12">
+                <iframe
+                  width="100%"
+                  height="300"
+                  frameborder="0" style="border:0"
+                  src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{event.place.name|urlencode}}%2C%20{{event.place.address|urlencode}}&zoom=17"
+                  allowfullscreen>
+                </iframe>
+              </div>
+
+            </div>
+            
             {% if event.enable_presentations %}
             <div class="row mb-2">
 	            <div class="col-3" width="120px"><b>{% trans "Presentations:" %}</b></div>

--- a/get_together/templates/get_together/places/show_place.html
+++ b/get_together/templates/get_together/places/show_place.html
@@ -37,6 +37,7 @@
             </tr>
             </table>
 
+            {% if settings.GOOGLE_MAPS_API_KEY %}
             <iframe
               width="720"
               height="400"
@@ -44,6 +45,7 @@
               src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{place.address|urlencode}}%2C%20{{place.city|urlencode}}&zoom=14"
               allowfullscreen>
             </iframe>
+            {% endif %}
 
         </div>
 

--- a/get_together/templates/get_together/places/show_place.html
+++ b/get_together/templates/get_together/places/show_place.html
@@ -41,7 +41,7 @@
               width="720"
               height="400"
               frameborder="0" style="border:0"
-              src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{place.name|urlencode}}%2C%20{{place.address|urlencode}}&zoom=17"
+              src="https://www.google.com/maps/embed/v1/place?key={{ settings.GOOGLE_MAPS_API_KEY }}&q={{place.address|urlencode}}%2C%20{{place.city|urlencode}}&zoom=14"
               allowfullscreen>
             </iframe>
 
@@ -65,4 +65,3 @@
     </div>
 </div>
 {% endblock %}
-


### PR DESCRIPTION
- added google maps in event detail page (see attached screenshot). File updated: get_together/templates/get_together/events/show_event.html 
![Added map](https://user-images.githubusercontent.com/34754144/57044733-8ada2a80-6c39-11e9-9142-79facfd14681.jpg)


- refactored google maps API code to accurately locate the address of the place (see attached screenshot). The original code was not able to accurately locate places that are not public or have multiple locations. File updated: get_together/templates/get_together/events/show_event.html
![Refactored google maps api query](https://user-images.githubusercontent.com/34754144/57044742-9299cf00-6c39-11e9-8f47-a3e7e6b1e449.jpg)

